### PR TITLE
Update google protobuf from 3.6.1 to 3.20.1

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -158,7 +158,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.6.1:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:3.20.1:exe:${os.detected.classifier}</protocArtifact>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <junit.version>5.7.0</junit.version>
         <lombok.version>1.18.16</lombok.version>
         <mockito.version>3.6.0</mockito.version>
-        <protobuf.version>3.13.0</protobuf.version>
+        <protobuf.version>3.20.1</protobuf.version>
         <reactor.version>3.4.0</reactor.version>
         <rxjava.version>2.2.2</rxjava.version>
         <servlet.api.version>3.1.0</servlet.api.version>

--- a/protobuf/pom.xml
+++ b/protobuf/pom.xml
@@ -83,7 +83,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.6.1:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:3.20.1:exe:${os.detected.classifier}</protocArtifact>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This update is needed to support development on M1 Macs.